### PR TITLE
Added missing libssh2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN set -xe \
         icu \
         libpng \
         libjpeg \
+        libssh2 \
         freetype \
         msttcorefonts-installer \
         fontconfig \


### PR DESCRIPTION
This library is required by ssh2 (php).

Fixes the following error:

> PHP Warning:  PHP Startup: Unable to load dynamic library 'ssh2.so' (tried: /usr/local/lib/php/extensions/no-debug-non-zts-20170718/ssh2.so (Error loading shared library libssh2.so.1: No such file or directory (needed by /usr/local/lib/php/extensions/no-debug-non-zts-20170718/ssh2.so)), /usr/local/lib/php/extensions/no-debug-non-zts-20170718/ssh2.so.so (Error loading shared library /usr/local/lib/php/extensions/no-debug-non-zts-20170718/ssh2.so.so: No such file or directory)) in Unknown on line 0